### PR TITLE
Upgrade Cake to 0.30.0

### DIFF
--- a/src/Cake.WindowsAppStore.Tests/Cake.WindowsAppStore.Tests.csproj
+++ b/src/Cake.WindowsAppStore.Tests/Cake.WindowsAppStore.Tests.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.1.1" />
-    <PackageReference Include="Cake.Core" Version="0.26.1" />
+    <PackageReference Include="Cake.Core" Version="0.28.0" />
     <PackageReference Include="FakeItEasy" Version="4.5.1" />
     <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Cake.WindowsAppStore/Cake.WindowsAppStore.csproj
+++ b/src/Cake.WindowsAppStore/Cake.WindowsAppStore.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.26.1">
+    <PackageReference Include="Cake.Core" Version="0.28.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />

--- a/src/Cake.WindowsAppStore/Internal/IngestionClient.cs
+++ b/src/Cake.WindowsAppStore/Internal/IngestionClient.cs
@@ -15,7 +15,7 @@
     /// <summary>
     /// This class is a proxy that abstracts the functionality of the API service
     /// </summary>
-    public class IngestionClient : IDisposable
+    internal class IngestionClient : IDisposable
     {
         public static readonly string Version = "1.0";
         public static readonly string Tenant = "my";

--- a/src/Cake.WindowsAppStore/Internal/MultiPartFormDataContentExtensions.cs
+++ b/src/Cake.WindowsAppStore/Internal/MultiPartFormDataContentExtensions.cs
@@ -4,7 +4,7 @@
     using System.Net.Http;
     using System.Net.Http.Headers;
 
-    public static class MultiPartFormDataContentExtensions
+    internal static class MultiPartFormDataContentExtensions
     {
         public static void AddIfNotEmpty(this MultipartFormDataContent content, string name, string value)
         {

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.25.0" />
+    <package id="Cake" version="0.30.0" />
 </packages>


### PR DESCRIPTION
This PR upgrades Cake references (Cake.Core) to 0.30.0 as well as the Cake version used by the build script.
Also made internal classes internal to suppress XML documentation warnings.